### PR TITLE
Use normal matrix 

### DIFF
--- a/samples/01-naive-renderer.html
+++ b/samples/01-naive-renderer.html
@@ -48,6 +48,10 @@
               binding: 0, // Node uniforms
               visibility: GPUShaderStage.VERTEX,
               buffer: {},
+            },{
+              binding: 1, // Node uniforms
+              visibility: GPUShaderStage.VERTEX,
+              buffer: {},
             }],
           });
 
@@ -93,6 +97,7 @@
               @group(0) @binding(0) var<uniform> camera : Camera;
 
               @group(1) @binding(0) var<uniform> model : mat4x4f;
+              @group(1) @binding(1) var<uniform> normalMatrix: mat4x4f;
 
               struct VertexInput {
                 @location(${ShaderLocations.POSITION}) position : vec3f,
@@ -109,7 +114,7 @@
                 var output : VertexOutput;
 
                 output.position = camera.projection * camera.view * model * vec4f(input.position, 1);
-                output.normal = normalize((camera.view * model * vec4f(input.normal, 0)).xyz);
+                output.normal = normalize((normalMatrix * vec4f(input.normal, 0)).xyz);
 
                 return output;
               }
@@ -148,6 +153,12 @@
           });
           this.device.queue.writeBuffer(nodeUniformBuffer, 0, node.worldMatrix);
 
+          const normalMatrixBuffer = this.device.createBuffer({
+            size: 16 * Float32Array.BYTES_PER_ELEMENT,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+          });
+          this.device.queue.writeBuffer(normalMatrixBuffer, 0, node.normalMatrix);
+
           // Create a bind group containing the uniform buffer for this node.
           const bindGroup = this.device.createBindGroup({
             label: `glTF Node BindGroup`,
@@ -155,6 +166,9 @@
             entries: [{
               binding: 0, // Node uniforms
               resource: { buffer: nodeUniformBuffer },
+            },{
+              binding: 1,
+              resource: { buffer: normalMatrixBuffer }
             }],
           });
 

--- a/samples/02-buffer-layouts.html
+++ b/samples/02-buffer-layouts.html
@@ -41,6 +41,10 @@
               binding: 0, // Node uniforms
               visibility: GPUShaderStage.VERTEX,
               buffer: {},
+            },{
+              binding: 1, // Node uniforms
+              visibility: GPUShaderStage.VERTEX,
+              buffer: {},
             }],
           });
 
@@ -77,6 +81,7 @@
               @group(0) @binding(0) var<uniform> camera : Camera;
 
               @group(1) @binding(0) var<uniform> model : mat4x4f;
+              @group(1) @binding(1) var<uniform> normalMatrix: mat4x4f;
 
               struct VertexInput {
                 @location(${ShaderLocations.POSITION}) position : vec3f,
@@ -93,7 +98,7 @@
                 var output : VertexOutput;
 
                 output.position = camera.projection * camera.view * model * vec4f(input.position, 1);
-                output.normal = normalize((camera.view * model * vec4f(input.normal, 0)).xyz);
+                output.normal = normalize((normalMatrix * vec4f(input.normal, 0)).xyz);
 
                 return output;
               }
@@ -131,12 +136,21 @@
           });
           this.device.queue.writeBuffer(nodeUniformBuffer, 0, node.worldMatrix);
 
+          const normalMatrixBuffer = this.device.createBuffer({
+            size: 16 * Float32Array.BYTES_PER_ELEMENT,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+          });
+          this.device.queue.writeBuffer(normalMatrixBuffer, 0, node.normalMatrix);
+
           const bindGroup = this.device.createBindGroup({
             label: `glTF Node BindGroup`,
             layout: this.nodeBindGroupLayout,
             entries: [{
               binding: 0, // Node uniforms
               resource: { buffer: nodeUniformBuffer },
+            },{
+              binding: 1,
+              resource: { buffer: normalMatrixBuffer }
             }],
           });
 

--- a/samples/03-pipeline-caching.html
+++ b/samples/03-pipeline-caching.html
@@ -39,6 +39,10 @@
               binding: 0, // Node uniforms
               visibility: GPUShaderStage.VERTEX,
               buffer: {},
+            },{
+              binding: 1, // Node uniforms
+              visibility: GPUShaderStage.VERTEX,
+              buffer: {},
             }],
           });
 
@@ -77,6 +81,7 @@
               @group(0) @binding(0) var<uniform> camera : Camera;
 
               @group(1) @binding(0) var<uniform> model : mat4x4f;
+              @group(1) @binding(1) var<uniform> normalMatrix: mat4x4f;
 
               struct VertexInput {
                 @location(${ShaderLocations.POSITION}) position : vec3f,
@@ -93,7 +98,7 @@
                 var output : VertexOutput;
 
                 output.position = camera.projection * camera.view * model * vec4f(input.position, 1);
-                output.normal = normalize((camera.view * model * vec4f(input.normal, 0)).xyz);
+                output.normal = normalize((normalMatrix * vec4f(input.normal, 0)).xyz);
 
                 return output;
               }
@@ -131,12 +136,21 @@
           });
           this.device.queue.writeBuffer(nodeUniformBuffer, 0, node.worldMatrix);
 
+          const normalMatrixBuffer = this.device.createBuffer({
+            size: 16 * Float32Array.BYTES_PER_ELEMENT,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+          });
+          this.device.queue.writeBuffer(normalMatrixBuffer, 0, node.normalMatrix);
+
           const bindGroup = this.device.createBindGroup({
             label: `glTF Node BindGroup`,
             layout: this.nodeBindGroupLayout,
             entries: [{
               binding: 0, // Node uniforms
               resource: { buffer: nodeUniformBuffer },
+            },{
+              binding: 1,
+              resource: { buffer: normalMatrixBuffer }
             }],
           });
 

--- a/samples/04-instancing.html
+++ b/samples/04-instancing.html
@@ -39,6 +39,10 @@
               binding: 0, // Node uniforms
               visibility: GPUShaderStage.VERTEX,
               buffer: { type: 'read-only-storage' },
+            },{
+              binding: 1,
+              visibility: GPUShaderStage.VERTEX,
+              buffer: { type: 'read-only-storage' },
             }],
           });
 
@@ -64,14 +68,21 @@
           }
 
           // Create a buffer large enough to contain all the instance matrices for the entire scene.
-          const instanceBuffer = this.device.createBuffer({
+          const modelMatricesBuffer = this.device.createBuffer({
             size: 16 * Float32Array.BYTES_PER_ELEMENT * primitiveInstances.total,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
             mappedAtCreation: true,
           });
 
           // Map the instance matrices buffer so we can write all the matrices into it.
-          primitiveInstances.arrayBuffer = new Float32Array(instanceBuffer.getMappedRange());
+          primitiveInstances.modelMatricesBuffer = new Float32Array(modelMatricesBuffer.getMappedRange());
+
+          const normalMatricesBuffer = this.device.createBuffer({
+            size: 16 * Float32Array.BYTES_PER_ELEMENT * primitiveInstances.total,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+            mappedAtCreation: true,
+          });
+          primitiveInstances.normalMatricesBuffer = new Float32Array(normalMatricesBuffer.getMappedRange());
 
           for (const mesh of gltf.meshes) {
             for (const primitive of mesh.primitives) {
@@ -80,7 +91,8 @@
           }
 
           // Unmap the buffer when we're finished writing all the instance matrices.
-          instanceBuffer.unmap();
+          modelMatricesBuffer.unmap();
+          normalMatricesBuffer.unmap();
 
           // Create a bind group for the instance buffer.
           this.instanceBindGroup = this.device.createBindGroup({
@@ -88,7 +100,10 @@
             layout: this.instanceBindGroupLayout,
             entries: [{
               binding: 0, // Instance storage buffer
-              resource: { buffer: instanceBuffer },
+              resource: { buffer: modelMatricesBuffer },
+            },{
+              binding: 1, // Instance storage buffer
+              resource: { buffer: normalMatricesBuffer },
             }],
           });
         }
@@ -105,6 +120,7 @@
               @group(0) @binding(0) var<uniform> camera : Camera;
 
               @group(1) @binding(0) var<storage> model : array<mat4x4f>;
+              @group(1) @binding(1) var<storage> normalMatrices : array<mat4x4f>;
 
               struct VertexInput {
                 @builtin(instance_index) instance : u32,
@@ -123,7 +139,8 @@
 
                 let modelMatrix = model[input.instance];
                 output.position = camera.projection * camera.view * modelMatrix * vec4f(input.position, 1);
-                output.normal = normalize((camera.view * modelMatrix * vec4f(input.normal, 0)).xyz);
+                let normalMatrix = normalMatrices[input.instance];
+                output.normal = normalize((normalMatrix * vec4f(input.normal, 0)).xyz);
 
                 return output;
               }
@@ -159,25 +176,27 @@
           for (const primitive of mesh.primitives) {
             let instances = primitiveInstances.matrices.get(primitive);
             if (!instances) {
-              instances = [];
+              instances = { modelMatrices:[], normalMatrices: [] };
               primitiveInstances.matrices.set(primitive, instances);
             }
-            instances.push(node.worldMatrix);
+            instances.modelMatrices.push(node.worldMatrix);
+            instances.normalMatrices.push(node.normalMatrix);
           }
           // Make sure to add the number of matrices used for this mesh to the total.
           primitiveInstances.total += mesh.primitives.length;
         }
 
         setupPrimitiveInstances(primitive, primitiveInstances) {
-          // Get the list of instance transform matricies for this primitive.
+          // Get the list of instance transform matrices for this primitive.
           const instances = primitiveInstances.matrices.get(primitive);
 
           const first = primitiveInstances.offset;
-          const count = instances.length;
+          const count = instances.modelMatrices.length;
 
           // Place the matrices in the instances buffer at the given offset.
           for (let i = 0; i < count; ++i) {
-            primitiveInstances.arrayBuffer.set(instances[i], (first + i) * 16);
+            primitiveInstances.modelMatricesBuffer.set(instances.modelMatrices[i], (first + i) * 16);
+            primitiveInstances.normalMatricesBuffer.set(instances.normalMatrices[i], (first + i) * 16);
           }
 
           // Update the offset for the next primitive.

--- a/samples/05-materials.html
+++ b/samples/05-materials.html
@@ -54,6 +54,10 @@
               binding: 0, // Node uniforms
               visibility: GPUShaderStage.VERTEX,
               buffer: { type: 'read-only-storage' },
+            },{
+              binding: 1,
+              visibility: GPUShaderStage.VERTEX,
+              buffer: { type: 'read-only-storage' },
             }],
           });
 
@@ -104,13 +108,19 @@
           }
 
           // Create a buffer large enough to contain all the instance matrices for the entire scene.
-          const instanceBuffer = this.device.createBuffer({
+          const modelMatricesBuffer = this.device.createBuffer({
             size: 16 * Float32Array.BYTES_PER_ELEMENT * primitiveInstances.total,
             usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
             mappedAtCreation: true,
           });
+          primitiveInstances.modelMatricesBuffer = new Float32Array(modelMatricesBuffer.getMappedRange());
 
-          primitiveInstances.arrayBuffer = new Float32Array(instanceBuffer.getMappedRange());
+          const normalMatricesBuffer = this.device.createBuffer({
+            size: 16 * Float32Array.BYTES_PER_ELEMENT * primitiveInstances.total,
+            usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+            mappedAtCreation: true,
+          });
+          primitiveInstances.normalMatricesBuffer = new Float32Array(normalMatricesBuffer.getMappedRange());
 
           for (const mesh of gltf.meshes) {
             for (const primitive of mesh.primitives) {
@@ -118,14 +128,18 @@
             }
           }
 
-          instanceBuffer.unmap();
+          modelMatricesBuffer.unmap();
+          normalMatricesBuffer.unmap();
 
           this.instanceBindGroup = this.device.createBindGroup({
             label: `glTF Instance BindGroup`,
             layout: this.instanceBindGroupLayout,
             entries: [{
               binding: 0, // Instance storage buffer
-              resource: { buffer: instanceBuffer },
+              resource: { buffer: modelMatricesBuffer },
+            },{
+              binding: 1, // Instance storage buffer
+              resource: { buffer: normalMatricesBuffer },
             }],
           });
         }
@@ -145,6 +159,7 @@
               @group(0) @binding(0) var<uniform> camera : Camera;
 
               @group(1) @binding(0) var<storage> model : array<mat4x4f>;
+              @group(1) @binding(1) var<storage> normalMatrices : array<mat4x4f>;
 
               struct Material {
                 baseColorFactor : vec4f,
@@ -176,7 +191,8 @@
 
                 let modelMatrix = model[input.instance];
                 output.position = camera.projection * camera.view * modelMatrix * vec4f(input.position, 1);
-                output.normal = normalize((camera.view * modelMatrix * vec4f(input.normal, 0)).xyz);
+                let normalMatrix = normalMatrices[input.instance];
+                output.normal = normalize((normalMatrix * vec4f(input.normal, 0)).xyz);
 
                 #if ${args.hasTexcoord}
                   output.texcoord = input.texcoord;
@@ -271,10 +287,11 @@
           for (const primitive of mesh.primitives) {
             let instances = primitiveInstances.matrices.get(primitive);
             if (!instances) {
-              instances = [];
+              instances = { modelMatrices:[], normalMatrices: [] };
               primitiveInstances.matrices.set(primitive, instances);
             }
-            instances.push(node.worldMatrix);
+            instances.modelMatrices.push(node.worldMatrix);
+            instances.normalMatrices.push(node.normalMatrix);
           }
           primitiveInstances.total += mesh.primitives.length;
         }
@@ -283,10 +300,11 @@
           const instances = primitiveInstances.matrices.get(primitive);
 
           const first = primitiveInstances.offset;
-          const count = instances.length;
+          const count = instances.modelMatrices.length;
 
           for (let i = 0; i < count; ++i) {
-            primitiveInstances.arrayBuffer.set(instances[i], (first + i) * 16);
+            primitiveInstances.modelMatricesBuffer.set(instances.modelMatrices[i], (first + i) * 16);
+            primitiveInstances.normalMatricesBuffer.set(instances.normalMatrices[i], (first + i) * 16);
           }
 
           primitiveInstances.offset += count;

--- a/samples/js/tiny-gltf.js
+++ b/samples/js/tiny-gltf.js
@@ -95,6 +95,9 @@ function setWorldMatrix(gltf, node, parentWorldMatrix) {
   }
 
   mat4.multiply(node.worldMatrix, parentWorldMatrix, node.worldMatrix);
+  node.normalMatrix = mat4.create();
+  mat4.invert(node.normalMatrix, node.worldMatrix);
+  mat4.transpose(node.normalMatrix, node.normalMatrix);
 
   // If the node has a mesh, get the AABB for that mesh and transform it to get the node's AABB.
   if ('mesh' in node) {


### PR DESCRIPTION
Hello, thank you for this series of articles. I've learned a lot about WebGPU from them. 

I noticed there's an issue with the normals in the examples, which differ from what I learned with OpenGL. The normal matrix should be the inverse transpose of the model matrix to ensure correct behavior when the model rotates.

And I believe this is correct, so I submitted this pull request.